### PR TITLE
Explicit CC-0 licensing

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
         "name" : "Douglas Crockford",
         "url" : "http://crockford.com/"
     },
-    "license" : "Public Domain"
+    "license" : "CC-0"
 }


### PR DESCRIPTION
IANAL. The declaration of "Public Domain" holds little legal meaning [according to the SPDX Legal Team](http://wiki.spdx.org/view/Legal_Team/Decisions/Dealing_with_Public_Domain_within_SPDX_Files). That is why it does not exist as an SPDX License Identifier. The closest general approximation is probably the Creative Commons Zero (CC-0) license.

Pending @douglascrockford opinion:
- https://github.com/douglascrockford/JSON-js/pull/70